### PR TITLE
fusemaps: imx8mp: extend uniqueid to 128 bit

### DIFF
--- a/cmd/crucible/fusemaps/IMX8MP.yaml
+++ b/cmd/crucible/fusemaps/IMX8MP.yaml
@@ -586,12 +586,25 @@ registers:
         offset: 0
         len: 32
 
+  OCOTP_UNIQUEID1:
+    bank: 40
+    word: 0
+    fuses:
+      UNIQUE_ID[95:64]:
+        offset: 0
+        len: 32
+  OCOTP_UNIQUEID2:
+    bank: 40
+    word: 1
+    fuses:
+      UNIQUE_ID[127:96]:
+        offset: 0
+        len: 32
+
 # The RM is not clear on bank/word addressing for the end of the fusemap, which
 # probably has an undetermined gap at its end. For this reason the following
 # fuses are not specified for now:
 #
-#     UNIQUE_ID[127:64]:
-#       len: 64
 #     GP6:
 #       len: 128
 #     GP7:


### PR DESCRIPTION
This fuse is not described in details in tecnical reference manuale but we ask NXP directly having confirm that is located in bank 40, reg 0/1

This is the extract from NXP technical support email

> The UID[127-64] located on bank 40, world 0 and word 1.

Anyway, from the initial test on hardware, we're doing something wrong, either in u-boot (where we're reading this UID from C code) or here in Crucible because I have different results :cry: 

In U-Boot we got

```
SOM UniqueID#: 1e261000:55aa2564:469660d3:d0c2b602
```

While with this patch Crucible says

```
root@desk-mx8mp:~# ./crucible -m IMX8MP -r 0 -b 16 -e big read UNIQUE_ID
soc:IMX8MP ref:0 otp:UNIQUE_ID op:read addr:0x8 off:0 len:128 val:0x01000000000247d11e26100055aa2564
```

That's a bit weird to me and, even if I cannot be 100% sure that U-Boot implementation is correct, I'm wondering what I'm doing wrong in Crucible..
Did I make some mistake in fuse definition?
IIUC 128 bit fuses are already supported/test in Crucible (e.g. iMX6UL/iMX6ULL) so I think it's not a crucible issue itself :thinking: 

