### PR TITLE
fusemap: disable ROM log buffer for the i.MX8MP

### DIFF
--- a/cmd/crucible/fusemaps/IMX8MP.yaml
+++ b/cmd/crucible/fusemaps/IMX8MP.yaml
@@ -287,6 +287,9 @@ registers:
       SDP_DISABLE:
         offset: 21
         len: 1
+      ROM_NO_LOG:
+        offset: 22
+        len: 1
       NOC_ID_REMAP_BYPASS:
         offset: 23
         len: 1


### PR DESCRIPTION
The user can burn this fuse to disable ROM log buffer, to enhance security.