### PR TITLE
fusemap: Enable TZASC for the i.MX8MP

### DIFF
--- a/cmd/crucible/fusemaps/IMX8MP.yaml
+++ b/cmd/crucible/fusemaps/IMX8MP.yaml
@@ -266,6 +266,9 @@ registers:
       WDOG_EN:
         offset: 10
         len: 1
+      TZASC_ENABLE:
+        offset: 11
+        len: 1
       ICACHE_DIS:
         offset: 12
         len: 1


### PR DESCRIPTION
Enable the TrustZone Address Space Controller